### PR TITLE
Relocatable package adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # CAP
  Correlation Analysis Package
+
+# Prerequisites
+- Valid `PYTHIA8` installation
+- Valid `root` installation built with `PYTHIA8` support
+- Environment variable for `PYTHIA8` location
+ ```
+ export PYTHIA8=<your_pythia8_directory>
+ ```
+- `root` environment activated with
+ ```
+ source <your_root_install_path>/bin/thisroot.sh
+ ```
+- massive storage path (for massive storage of `root` files)
+ ```
+ export CAP_LARGE_DATA=<your_massive_storage_path>
+ ```
+
+# Build CAP
+```
+cd <your_cap_directory>
+source Setup_CAP.sh
+mkdir build
+cd build
+cmake ../src
+make install
+```

--- a/Setup_CAP.sh
+++ b/Setup_CAP.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ####################################################################################################
 #
 # Use this file to setup envirionment variable to run CAP applications
@@ -26,16 +28,14 @@
 ####################################################################################################
 echo "========================================================================================"
 echo "Creating (if needed) build, InputFiles, and OutputFiles directories"
-if [[ ! (-d build) ]] then
+if [[ ! (-d build) ]]
+then
   mkdir build;
 fi
 
 echo "========================================================================================"
 echo "Setting up CAP environment variables"
 echo "========================================================================================"
-export ROOT_SELECTED_VERSION="/Users/aa7526/opt/root/root_build"
-export ROOT_LIBS="$ROOT_SELECTED_VERSION/lib/"
-export CAP_LARGE_DATA="/Volumes/ClaudeDisc4/CAP4/"
 export CAP_ROOT=`pwd`
 export CAP_SRC="$CAP_ROOT/src/"
 export CAP_BIN="$CAP_ROOT/bin/"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
 #---Locate the ROOT package and defines a number of variables (e.g. ROOT_INCLUDE_DIRS)
 find_package(ROOT REQUIRED COMPONENTS EG MathCore MathMore RIO Hist Tree Net )
-find_library(PYTHIA8_LIB pythia8 PATHS $ENV{PYTHIA8_LIBRARIES})
+find_library(PYTHIA8_LIB pythia8 PATHS $ENV{PYTHIA8}/lib)
 find_library(EGPYTHIA8 EGPythia8)
 
 
@@ -52,7 +52,7 @@ add_subdirectory(NuDyn)
 add_subdirectory(Performance)
 add_subdirectory(CollGeom)
 #add_subdirectory(Blastwave)
-add_subdirectory(Epos)
+#add_subdirectory(Epos)
 #add_subdirectory(LambdaAnalysis)
 #add_subdirectory(Music)
 #add_subdirectory(Urqmd)


### PR DESCRIPTION
In principle this makes CAP relocatable and only with `root` and `Pythia8` dependencies
Check that it is valid also for you installing it somewhere else